### PR TITLE
Fix Elixir warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
-# docker-elixir
-Base elixir docker images
+# Elixir Docker images from Avvo
 
-Perfect for use with CircleCI 2.0 and mix_docker.
+These Dockerfiles are used to build docker images we use for various Elixir
+containers at Avvo.
 
-* [avvo/elixir-circleci](https://hub.docker.com/r/avvo/elixir-circleci/) for
-  running tests and building the release tarball
-* [avvo/elixir-release](https://hub.docker.com/r/avvo/elixir-release/) for
-  putting the tarball in
+## Development
+
+1. Clone this repo
+2. Edit the Dockerfile you want to update
+4. Build and push an image with a version tag:
+```
+cd elixir-circleci
+../push.sh '1.4.1-4'
+```
+
+Two notes:
+
+a. You need permissions to write the images on dockerhub. If you're not an 
+Avvo person, you probably don't have access. You can push it up to your own 
+namespace.
+
+b. Test out your changes on a tag before committing and pushing to latest.
+
+## License
+
+MIT Licence. Do what you want, this is just configuration, nothing special.

--- a/elixir-circleci/Dockerfile
+++ b/elixir-circleci/Dockerfile
@@ -1,19 +1,29 @@
 FROM ubuntu:xenial
 
-ENV TERM=xterm \
-  MIX_ENV=test \
-  LANG=en_US.UTF-8 \
-  LC_CTYPE=en_US.UTF-8 \
-  LC_ALL=en_US.UTF-8
+ENV \
+  LC_ALL='en_US.UTF-8'\
+  LC_CTYPE='en_US.UTF-8' \
+  MIX_ENV='test' \
+  TERM='xterm'
 
-RUN apt-get update \
-  && apt-get -y upgrade \
-  && apt-get -y install curl git openssh-client \
-  && curl -o /tmp/erlang-solutions_1.0_all.deb \
-     https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
-  && dpkg -i /tmp/erlang-solutions_1.0_all.deb \
+RUN \
+  set -xe \
+  && ERLANG_PKG='erlang-solutions_1.0_all.deb' \
+  && ERLANG_URL="https://packages.erlang-solutions.com/${ERLANG_PKG}" \
   && apt-get update \
-  && apt-get -y install esl-erlang=1:19.3 elixir=1.4.1-1 \
+  && apt-get -y upgrade \
+  && apt-get -y install \
+    curl \
+    git \
+    openssh-client \
+  && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
+  && dpkg -i "/tmp/${ERLANG_PKG}" \
+  && apt-get update \
+  && apt-get -y install \
+    esl-erlang=1:19.3 \
+    elixir=1.4.1-1 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN mix local.hex --force && mix local.rebar --force
+RUN \
+  mix local.hex --force \
+  && mix local.rebar --force

--- a/elixir-circleci/Dockerfile
+++ b/elixir-circleci/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:xenial
 
 ENV \
-  LC_ALL='en_US.UTF-8'\
-  LC_CTYPE='en_US.UTF-8' \
+  LANG='C.UTF-8' \
   MIX_ENV='test' \
   TERM='xterm'
 

--- a/elixir-release/Dockerfile
+++ b/elixir-release/Dockerfile
@@ -1,5 +1,11 @@
 FROM alpine:3.5
 
-RUN apk update && \
-    apk --no-cache --update add libgcc libstdc++ ncurses-libs libcrypto1.0 && \
-    rm -rf /var/cache/apk/*
+RUN \
+  set -xe \
+  && apk update \
+  && apk --no-cache --update add \
+    libcrypto1.0 \
+    libgcc \
+    libstdc++ \
+    ncurses-libs \
+  && rm -rf /var/cache/apk/*

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+VERSION=$1
+if [ -z ${VERSION} ]; then
+  echo "Please provide a Docker image version tag"
+  exit 1
+fi
+
+set -x
+
+IMAGE="avvo/$(basename $(pwd))"
+
+docker build -t "${IMAGE}:${VERSION}" -t "${IMAGE}:latest" .
+docker push "${IMAGE}:${VERSION}"
+docker push "${IMAGE}:latest"


### PR DESCRIPTION
The existing `elixir-circleci/Dockerfile` resulted in an Elixir build which emitted warnings. This PR fixes that.

During Docker image builds, the following errors show several times:

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
  LANGUAGE = (unset),
  LC_ALL = "en_US.UTF-8",
  LC_CTYPE = "en_US.UTF-8",
  LANG = (unset)
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
...
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
...
warning: the VM is running with native name encoding of latin1 which may cause 
Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 
(which can be verified by running "locale" in your shell)
```
The trick is to define `LANG='C.UTF-8'`. Building an image from the new Dockerfile no longer emits the above errors.
