### PR TITLE
add postgres client to elixir circle image

### DIFF
--- a/elixir-circleci/Dockerfile
+++ b/elixir-circleci/Dockerfile
@@ -23,7 +23,7 @@ RUN \
     build-essential \
     mysql-client \
     libmysqlclient-dev \
-    postgresql-client-9.6 \
+    postgresql-client \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \

--- a/elixir-circleci/Dockerfile
+++ b/elixir-circleci/Dockerfile
@@ -23,6 +23,7 @@ RUN \
     build-essential \
     mysql-client \
     libmysqlclient-dev \
+    postgresql-client-9.6 \
   && curl -o "/tmp/${ERLANG_PKG}" ${ERLANG_URL} \
   && dpkg -i "/tmp/${ERLANG_PKG}" \
   && apt-get update \


### PR DESCRIPTION
# WHAT
add postgres-client to the docker-elixir base image so that folks can choose between RDBMS'

## requesting feedback on
* The postgres-client was added directly to the docker-elixir image, in addition to the mysql-client. This bloats the image a little bit but not by very much (the client is ~1MB)
* A specific version of the postgres-client is specified even though other install statements just get the latest version. We are currently using Postgres 9.6 in prod, so that's why we call out a specific version of the client.