### PR TITLE
Elixir 1.9.1 and erlang 22.0.7 images

### DIFF
--- a/elixir/1.9.1/Dockerfile
+++ b/elixir/1.9.1/Dockerfile
@@ -1,0 +1,50 @@
+FROM avvo/erlang:22.0.7
+
+# Adapted from:
+#   https://github.com/c0b/docker-elixir/blob/master/1.9/Dockerfile
+#
+# For latest NODE_VERSION, see: https://github.com/nodesource/distributions/tree/master/deb
+
+ENV \
+  ELIXIR_VERSION='v1.9.1' \
+  ELIXIR_DOWNLOAD_SHA256="94daa716abbd4493405fb2032514195077ac7bc73dc2999922f13c7d8ea58777" \
+  NODE_VERSION='10' \
+  HOME='/opt/app/' \
+  LANG='C.UTF-8' \
+  MIX_ENV='test' \
+  TERM='xterm'
+
+WORKDIR "${HOME}"
+
+RUN \
+  set -xe \
+  && apt-get update -qq \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+    build-essential \
+    git \
+    libmysqlclient-dev \
+    postgresql-client \
+    mysql-client \
+    software-properties-common \
+  && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+  && curl -fSL -o elixir-src.tar.gz "${ELIXIR_DOWNLOAD_URL}" \
+  && echo "${ELIXIR_DOWNLOAD_SHA256}  elixir-src.tar.gz" | sha256sum -c - \
+  && mkdir -p /usr/local/src/elixir \
+  && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+  && rm elixir-src.tar.gz \
+  && cd /usr/local/src/elixir \
+  && make install clean \
+  && cd "${HOME}" \
+  && curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash - \
+  && apt-get update -qq \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+    nodejs \
+  && rm -rf '/var/lib/apt/lists/*' \
+  && mix local.hex --force \
+  && mix local.rebar --force \
+  && mkdir -p '/root/.ssh' \
+  && ssh-keyscan -t rsa github.com > '/root/.ssh/known_hosts' \
+  && chmod 700 '/root/.ssh' \
+  && chmod 600 '/root/.ssh/known_hosts'

--- a/erlang/22.0.7/Dockerfile
+++ b/erlang/22.0.7/Dockerfile
@@ -1,0 +1,85 @@
+FROM avvo/ubuntu:xenial
+
+# Adapted from: https://github.com/erlang/docker-erlang-otp/blob/master/22/Dockerfile
+
+ENV \
+  OTP_VERSION="22.0.7" \
+  OTP_DOWNLOAD_SHA256="04c090b55ec4a01778e7e1a5b7fdf54012548ca72737965b7aa8c4d7878c92bc" \
+  REBAR_VERSION="2.6.4" \
+  REBAR_DOWNLOAD_SHA256="577246bafa2eb2b2c3f1d0c157408650446884555bf87901508ce71d5cc0bd07" \
+  REBAR3_VERSION="3.11.1" \
+  REBAR3_DOWNLOAD_SHA256="a1822db5210b96b5f8ef10e433b22df19c5fc54dfd847bcaab86c65151ce4171"
+
+# We'll install the build dependencies for erlang-odbc along with the erlang
+# build process:
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& runtimeDeps=' \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      libgcrypt11-dev \
+      libodbc1 \
+			libsctp1 \
+      libssl-dev \
+			libwxgtk3.0 \
+      openssh-client \
+    ' \
+	&& buildDeps=' \
+      autoconf \
+      build-essential \
+      libncurses5-dev \
+      libncursesw5-dev \
+      unixodbc-dev \
+      libsctp-dev \
+      libwxgtk3.0-dev \
+    ' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $runtimeDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp "${ERL_TOP}" \
+	&& tar -xzf otp-src.tar.gz -C "${ERL_TOP}" --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( \
+    cd "${ERL_TOP}" \
+	  && ./otp_build autoconf \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="${gnuArch}" \
+	  && make -j$(nproc) \
+	  && make install \
+  ) \
+	&& find /usr/local -name examples | xargs rm -rf \
+	&& apt-get purge -y --auto-remove ${buildDeps} \
+	&& rm -rf "${ERL_TOP}" /var/lib/apt/lists/*
+
+CMD ["erl"]
+
+# extra useful tools here: rebar & rebar3
+
+RUN set -xe \
+	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
+	&& mkdir -p /usr/src/rebar-src \
+	&& curl -fSL -o rebar-src.tar.gz "${REBAR_DOWNLOAD_URL}" \
+	&& echo "${REBAR_DOWNLOAD_SHA256} rebar-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar-src.tar.gz -C /usr/src/rebar-src --strip-components=1 \
+	&& rm rebar-src.tar.gz \
+	&& cd /usr/src/rebar-src \
+	&& ./bootstrap \
+	&& install -v ./rebar /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar-src
+
+
+RUN set -xe \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "${REBAR3_DOWNLOAD_SHA256} rebar3-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src


### PR DESCRIPTION
I don't have access to avvo's  docker hub. Couldn't pull `avvo/ubuntu:xenial`
This is how I tested locally:

1) Created Erlang image with this Dockerfile but `FROM ubuntu:xenial` (I guess avvo/ubuntu:xenial is mostly compatible with that)

2) Then created Elixir image from local Erlang image created in previous step.